### PR TITLE
Fix for building on 5.4.+ kernels. SUBDIRS is no longer parsed by Kbuild

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,8 +1,8 @@
 PACKAGE_NAME=i2c-ch341-usb
 PACKAGE_VERSION="1.0.0"
 
-MAKE[0]="make -C ${kernel_source_dir} SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
-CLEAN="make -C ${kernel_source_dir} SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
+CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
 
 BUILT_MODULE_NAME[0]=i2c-ch341-usb
 #DEST_MODULE_LOCATION[0]=/kernel/drivers/i2c/busses


### PR DESCRIPTION
The "sudo make install" command failed without this patch, at least on Ubuntu 20.04.
It is the same pull request as this one: [https://github.com/gschorcht/spi-ch341-usb/pull/16](https://github.com/gschorcht/spi-ch341-usb/pull/16).

Just for info for other people having the same problem, the failure gave the following message:
```
$ sudo make install

Creating symlink /var/lib/dkms/i2c-ch341-usb/1.0.0/source ->
                 /usr/src/i2c-ch341-usb-1.0.0

DKMS: add completed.

Kernel preparation unnecessary for this kernel.  Skipping...

Building module:
cleaning build area...(bad exit status: 2)
make -j8 KERNELRELEASE=5.8.0-29-generic -C /lib/modules/5.8.0-29-generic/build SUBDIRS=/var/lib/dkms/i2c-ch341-usb/1.0.0/build modules...(bad exit status: 2)
ERROR (dkms apport): binary package for i2c-ch341-usb: 1.0.0 not found
Error! Bad return status for module build on kernel: 5.8.0-29-generic (x86_64)
Consult /var/lib/dkms/i2c-ch341-usb/1.0.0/build/make.log for more information.
make: *** [Makefile:46: install] Error 10
```
The make.log content was:
```
KMS make.log for i2c-ch341-usb-1.0.0 for kernel 5.8.0-29-generic (x86_64)
Sun 29 Nov 2020 19:02:25 CET
make[1]: Entering directory '/usr/src/linux-headers-5.8.0-29-generic'
  DESCEND  objtool
make[2]: *** No rule to make target 'arch/x86/tools/relocs_32.c', needed by 'arch/x86/tools/relocs_32.o'. Stop.
make[1]: *** [arch/x86/Makefile:211: archscripts] Error 2
make[1]: *** Waiting for unfinished jobs....
/usr/src/linux-headers-5.8.0-29-generic/tools/build/Makefile.build:37: /usr/src/linux-headers-5.8.0-29-generic/tools/build/Build.include: No such file or directory
make[5]: *** No rule to make target '/usr/src/linux-headers-5.8.0-29-generic/tools/build/Build.include'. Stop.
make[4]: *** [Makefile:43: /usr/src/linux-headers-5.8.0-29-generic/tools/objtool/fixdep-in.o] Error 2
make[3]: *** [/usr/src/linux-headers-5.8.0-29-generic/tools/build/Makefile.include:5: fixdep] Error 2
make[2]: *** [Makefile:68: objtool] Error 2
make[1]: *** [Makefile:1882: tools/objtool] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-5.8.0-29-generic'
```