### PR TITLE
Fix "ERROR: modpost: 'irq_to_desc' undefined!"

### DIFF
--- a/i2c-ch341-usb.c
+++ b/i2c-ch341-usb.c
@@ -657,7 +657,7 @@ static int ch341_irq_probe (struct ch341_device* ch341_dev)
 
     for (i = 0; i < ch341_dev->irq_num; i++)
     {
-        ch341_dev->irq_descs[i]   = irq_to_desc(ch341_dev->irq_base + i);
+        ch341_dev->irq_descs[i] = irq_data_to_desc( irq_get_irq_data(ch341_dev->irq_base + i) );
         ch341_dev->irq_enabled[i] = false;
 
         irq_set_chip          (ch341_dev->irq_base + i, &ch341_dev->irq);


### PR DESCRIPTION
See https://github.com/gschorcht/i2c-ch341-usb/issues/6#issue-1068382418